### PR TITLE
Add keyboard shortcut helper modal (closes #28)

### DIFF
--- a/app/static/eventListeners.js
+++ b/app/static/eventListeners.js
@@ -13,7 +13,48 @@
  */
 
 import ProjectController from "./js/controllers/projectController.js";
+
+// Variable to track keyboard shortcuts modal state
+let keyboardShortcutsModal = null;
+
 export function addEventListeners() {
+    // Initialize keyboard shortcuts modal reference
+    document.addEventListener('DOMContentLoaded', function() {
+        keyboardShortcutsModal = new bootstrap.Modal(document.getElementById('keyboardShortcutsModal'));
+    });
+
+    // Handle question mark key for keyboard shortcuts helper
+    document.addEventListener('keydown', function(event) {
+        // Check for question mark key (? or Shift + /)
+        if (event.key === '?' || (event.key === '/' && event.shiftKey)) {
+            // Don't show modal if user is typing in form inputs
+            const activeElement = document.activeElement;
+            const isInInput = activeElement && (
+                activeElement.tagName === 'INPUT' || 
+                activeElement.tagName === 'TEXTAREA' || 
+                activeElement.tagName === 'SELECT' ||
+                activeElement.contentEditable === 'true' ||
+                activeElement.closest('.modal') // ignore if another modal is already open
+            );
+            
+            if (!isInInput && keyboardShortcutsModal) {
+                event.preventDefault();
+                keyboardShortcutsModal.show();
+                return;
+            }
+        }
+    });
+
+    // Hide keyboard shortcuts modal on keyup (Google Calendar style)
+    document.addEventListener('keyup', function(event) {
+        if ((event.key === '?' || event.key === '/') && keyboardShortcutsModal) {
+            // Small delay to prevent immediate close if user releases key quickly
+            setTimeout(() => {
+                keyboardShortcutsModal.hide();
+            }, 50);
+        }
+    });
+
     document.addEventListener('keydown', function(event) {
         // ignore keydown events when user is typing in form inputs
         const activeElement = document.activeElement;

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -655,3 +655,80 @@ body.dark-mode .visualization-container * {
     background-color: #0b5ed7 !important;
     border-color: #0b5ed7;
 }
+
+/* Keyboard Shortcuts Modal Styling */
+#keyboardShortcutsModal .modal-body {
+    padding: 1.5rem;
+}
+
+.shortcut-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    border-bottom: 1px solid #f1f3f4;
+}
+
+.shortcut-item:last-child {
+    border-bottom: none;
+}
+
+.shortcut-keys {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 120px;
+}
+
+.shortcut-keys kbd {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 6px;
+    color: #495057;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.85em;
+    font-weight: 600;
+    padding: 4px 8px;
+    box-shadow: 0 1px 0 rgba(27, 31, 35, 0.04), inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    text-shadow: none;
+}
+
+.shortcut-description {
+    flex: 1;
+    color: #6c757d;
+    font-size: 0.9rem;
+}
+
+/* Dark mode support for keyboard shortcuts modal */
+body.dark-mode #keyboardShortcutsModal .modal-content {
+    background-color: #2d3436;
+    border-color: #636e72;
+}
+
+body.dark-mode #keyboardShortcutsModal .modal-header {
+    border-bottom-color: #636e72;
+}
+
+body.dark-mode #keyboardShortcutsModal .modal-title,
+body.dark-mode #keyboardShortcutsModal h6 {
+    color: #ddd;
+}
+
+body.dark-mode .shortcut-item {
+    border-bottom-color: #636e72;
+}
+
+body.dark-mode .shortcut-keys kbd {
+    background-color: #636e72;
+    border-color: #74b9ff;
+    color: #ddd;
+    box-shadow: 0 1px 0 rgba(116, 185, 255, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .shortcut-description {
+    color: #b2bec3;
+}
+
+body.dark-mode #keyboardShortcutsModal .text-muted {
+    color: #b2bec3 !important;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -149,6 +149,89 @@
 
     {% include 'model_selection.html' %}
 
+    <!-- Keyboard Shortcuts Helper Modal -->
+    <div class="modal fade" id="keyboardShortcutsModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        <i class="bi bi-keyboard me-2"></i>
+                        Keyboard Shortcuts
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <h6 class="text-muted mb-3">General</h6>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>?</kbd>
+                                </div>
+                                <div class="shortcut-description">Show/hide this help</div>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <h6 class="text-muted mb-3">Visualization View</h6>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>n</kbd>
+                                </div>
+                                <div class="shortcut-description">Navigate to next session</div>
+                            </div>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>p</kbd>
+                                </div>
+                                <div class="shortcut-description">Navigate to previous session</div>
+                            </div>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>r</kbd>
+                                </div>
+                                <div class="shortcut-description">Create new bout</div>
+                            </div>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>b</kbd>
+                                </div>
+                                <div class="shortcut-description">Score visible range with model</div>
+                            </div>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>s</kbd>
+                                </div>
+                                <div class="shortcut-description">Toggle split mode</div>
+                            </div>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>v</kbd>
+                                </div>
+                                <div class="shortcut-description">Toggle verified status</div>
+                            </div>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>Ctrl</kbd> + <kbd>s</kbd>
+                                </div>
+                                <div class="shortcut-description">Split session</div>
+                            </div>
+                            <div class="shortcut-item">
+                                <div class="shortcut-keys">
+                                    <kbd>Ctrl</kbd> + <kbd>d</kbd>
+                                </div>
+                                <div class="shortcut-description">Return to table view</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mt-4 text-muted small">
+                        <i class="bi bi-info-circle me-2"></i>
+                        Keyboard shortcuts are only active when not typing in form fields.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- Implements keyboard shortcut helper modal that shows when holding question mark key
- Provides Google Calendar-style help experience with organized shortcuts by context
- Includes comprehensive styling with dark mode support

## Changes Made
- **Modal Structure**: Added Bootstrap modal to `base.html` with organized shortcut layout
- **Event Handling**: Enhanced `eventListeners.js` with question mark key detection and proper input field filtering
- **Styling**: Added polished CSS with dark mode support and proper keyboard key styling

## Features
- Shows on keydown, hides on keyup (Google Calendar behavior)
- Organized shortcuts by context (General vs Visualization View)
- Respects existing input field detection logic
- Bootstrap-consistent styling with dark mode support
- Prevents showing when typing in forms or when other modals are open

## Test Plan
- [x] Modal appears when holding `?` key
- [x] Modal disappears when releasing key
- [x] Does not interfere when typing in form inputs
- [x] Works properly in both light and dark modes
- [x] All documented shortcuts are accurate and functional

🤖 Generated with [Claude Code](https://claude.ai/code)