### PR TITLE
Add export button for individual labelings in labeling modal (closes #50)

### DIFF
--- a/app/static/js/api/projectAPI.js
+++ b/app/static/js/api/projectAPI.js
@@ -197,6 +197,28 @@ export class ProjectAPI {
     }
 
     /**
+     * Export a specific labeling as JSON
+     * @param {string|number} projectId
+     * @param {string} labelingName
+     * @returns {Promise<Object>}
+     */
+    static async exportLabeling(projectId, labelingName) {
+        try {
+            const response = await fetch(`/api/export/labeling/${projectId}/${encodeURIComponent(labelingName)}`);
+            
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.error || 'Failed to export labeling');
+            }
+
+            return await response.json();
+        } catch (error) {
+            console.error('Error exporting labeling:', error);
+            throw error;
+        }
+    }
+
+    /**
      * Create a new project with file upload
      * @param {FormData} uploadData - The FormData object ready for upload
      * @returns {Promise<Object>} The upload result

--- a/app/static/js/controllers/projectController.js
+++ b/app/static/js/controllers/projectController.js
@@ -132,6 +132,9 @@ export class ProjectController {
                             <span>${labelingName}</span>
                         </div>
                         <div class="labeling-actions d-flex gap-1">
+                            <button class="btn btn-sm btn-outline-success" onclick="exportLabelingJSON('${labelingName.replace(/'/g, "\\'")}'); return false;" title="Export Labeling">
+                                <i class="bi bi-download"></i>
+                            </button>
                             <button class="btn btn-sm btn-outline-secondary" onclick="editLabeling('${labelingName.replace(/'/g, "\\'")}'); return false;" title="Edit Labeling">
                                 <i class="bi bi-pencil"></i>
                             </button>

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1297,6 +1297,44 @@ async function exportLabelsJSON() {
     }
 }
 
+async function exportLabelingJSON(labelingName) {
+    try {
+        if (!currentProjectId) {
+            throw new Error('No project selected');
+        }
+
+        const response = await ProjectAPI.exportLabeling(currentProjectId, labelingName);
+        
+        // Create downloadable JSON file
+        const jsonString = JSON.stringify(response, null, 2);
+        const blob = new Blob([jsonString], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        
+        // Create download link with project name and labeling name
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').split('T')[0] + '_' + 
+                         new Date().toISOString().replace(/[:.]/g, '-').split('T')[1].split('-')[0];
+        const projectName = response.project_name.replace(/[^a-zA-Z0-9]/g, '_');
+        const safeLabelingName = labelingName.replace(/[^a-zA-Z0-9]/g, '_');
+        const filename = `${projectName}_${safeLabelingName}_export_${timestamp}.json`;
+        
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        
+        // Success - file downloaded automatically
+        console.log(`Successfully exported labeling "${labelingName}" with ${response.total_sessions} sessions and ${response.total_bouts} bouts to ${filename}`);
+        showNotification(`Exported labeling "${labelingName}" successfully`, 'success');
+        
+    } catch (error) {
+        console.error('Error exporting labeling JSON:', error);
+        showNotification('Failed to export labeling: ' + error.message, 'error');
+    }
+}
+
 function updateSidebarHighlighting() {
     // Remove active-session class from all links
     document.querySelectorAll('#session-list .nav-link').forEach(link => {
@@ -1377,6 +1415,7 @@ window.showBulkUploadForm = showBulkUploadForm;
 window.updateSidebarHighlighting = updateSidebarHighlighting;
 window.updateSessionsList = updateSessionsList;
 window.exportLabelsJSON = exportLabelsJSON;
+window.exportLabelingJSON = exportLabelingJSON;
 window.showBulkUploadForm = showBulkUploadForm;
 window.pollScoringStatus = pollScoringStatus;
 window.deleteProject = ProjectController.deleteProject;


### PR DESCRIPTION
## Summary
- Added export functionality for individual labelings in the labeling modal
- Users can now export project-specific labeling data in JSON format
- Export button appears next to each labeling with download icon

## Implementation Details
- **Backend**: New `/api/export/labeling/<project_id>/<labeling_name>` endpoint
- **Frontend**: Export button added to labeling modal with download functionality  
- **Data filtering**: Only includes sessions containing bouts for the specified labeling
- **File naming**: `{project_name}_{labeling_name}_export_{timestamp}.json`

## Features
✅ Export button next to each labeling in modal  
✅ Project-specific export (only sessions with bouts for that labeling)  
✅ JSON format matching existing global export structure  
✅ Automatic file download with descriptive naming  
✅ Success/error notifications  

## Testing
- [x] Export button appears in labeling modal
- [x] Clicking export downloads JSON file
- [x] File contains only relevant session data
- [x] Error handling for missing projects/labelings

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)